### PR TITLE
Add Github CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Check for Github Actions version updates (for CI/CD)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - feature/github-ci
 
 name: ci-master
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - master
       - feature/*
+  pull_request:
+    branches:
+      - master
+    types: [opened, reopened]
 
 name: build
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -2,11 +2,10 @@ on:
   push:
     branches:
       - master
-      - feature/*
   pull_request:
     branches:
       - master
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 name: build
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - master
+
+name: ci-master
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    # Copied verbatim from https://docs.platformio.org/en/stable/integration/ci/github-actions.html
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/cache
+          key: ${{ runner.os }}-arch
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -7,7 +7,7 @@ on:
       - master
     types: [opened, reopened, synchronize]
 
-name: build
+name: ci-master
 
 jobs:
 

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,10 +1,6 @@
 on:
-  push:
-    branches:
-      - master
-      - feature/*
-
-name: build
+  release:
+    types: [published, created]
 
 jobs:
 
@@ -31,3 +27,11 @@ jobs:
 
       - name: Build PlatformIO Project
         run: pio run
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: .pio/build/**/firmware.bin
+          asset_name: ShockLink.bin
+          tag: ${{ github.ref }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -2,6 +2,8 @@ on:
   release:
     types: [published]
 
+name: push-release
+
 jobs:
 
   # Copied verbatim from https://docs.platformio.org/en/stable/integration/ci/github-actions.html

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [published, created]
+    types: [published]
 
 jobs:
 

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -33,5 +33,5 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: .pio/build/ShockLink/firmware.bin
-          asset_name: ShockLink.bin
+          asset_name: ShockLink-${{ github.ref_name }}.bin
           tag: ${{ github.ref }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -32,6 +32,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: .pio/build/**/firmware.bin
+          file: .pio/build/ShockLink/firmware.bin
           asset_name: ShockLink.bin
           tag: ${{ github.ref }}


### PR DESCRIPTION
Hi,

I've added two CI workflows using Github Actions/Workflows/Runners. For open source I think there's 2000 free CI minutes a month, should last a while :-).

## `ci-master`
Triggers when the `master` branch is modified, or when a pull request to merge into the `master` branch is opened/reopened/updated.

Performs no permanent changes, simply builds the project. Fails if the build fails. No tests are included as of yet.

- Push example: https://github.com/redmushie/ShockLink-Firmware/actions/runs/6223907654
- PR Example: https://github.com/redmushie/ShockLink-Firmware/pull/1

## `push-release`
Triggers on the creation of a release. Builds the project and uploads the binary to the release.

There's also room for a `push-tag` workflow here but for simplicity of the initial PR I've decided to omit it.

- Example: https://github.com/redmushie/ShockLink-Firmware/releases/tag/v5

## Future improvements
Possible future improvements:
- Add automatic running of unit tests
- Add automatic creation of minor releases on tag pushes

## Final words

I'm aware of the rewrite; that's fine, this can probably be migrated verbatim when that comes around. Hope to see this merged! :)

