### PR TITLE
Embed API URL and firmware version from CI

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -9,6 +9,10 @@ on:
 
 name: ci-master
 
+env:
+  SHOCKLINK_API_URL: api.shocklink.net
+  SHOCKLINK_FW_VERSION: master-${{ github.sha }}
+
 jobs:
 
   # Copied verbatim from https://docs.platformio.org/en/stable/integration/ci/github-actions.html

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           path: |
             ~/.cache/pip
+            ~/.platformio/platforms
+            ~/.platformio/packages
             ~/.platformio/cache
           key: ${{ runner.os }}-arch
 

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -5,6 +5,10 @@ on:
 
 name: ci-tag
 
+env:
+  SHOCKLINK_API_URL: api.shocklink.net
+  SHOCKLINK_FW_VERSION: ${{ github.ref_name }}
+
 jobs:
 
   # Copied verbatim from https://docs.platformio.org/en/stable/integration/ci/github-actions.html

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           path: |
             ~/.cache/pip
+            ~/.platformio/platforms
+            ~/.platformio/packages
             ~/.platformio/cache
           key: ${{ runner.os }}-arch
 

--- a/embed_firmware_version.py
+++ b/embed_firmware_version.py
@@ -1,10 +1,13 @@
+import os
 
 Import("env")
 
+shocklinkApiUrl = os.getenv('SHOCKLINK_API_URL') or "api.shocklink.net"
+shocklinkFwVersion = os.getenv('SHOCKLINK_FW_VERSION') or "0.8.1"
+
 env.Append(CPPDEFINES=[
-    ("SHOCKLINK_API_URL", env.StringifyMacro("api.shocklink.net")),
-    ("SHOCKLINK_DEV_API_URL", env.StringifyMacro("dev-api.shocklink.net")),
-    ("SHOCKLINK_FW_VERSION", env.StringifyMacro("0.8.1"))
+    ("SHOCKLINK_API_URL", env.StringifyMacro(shocklinkApiUrl)),
+    ("SHOCKLINK_FW_VERSION", env.StringifyMacro(shocklinkFwVersion))
 ])
 
 print(env.Dump())

--- a/embed_firmware_version.py
+++ b/embed_firmware_version.py
@@ -2,9 +2,9 @@
 Import("env")
 
 env.Append(CPPDEFINES=[
-    ("SHOCKLINK_API_URL", "api.shocklink.net"),
-    ("SHOCKLINK_DEV_API_URL", "dev-api.shocklink.net"),
-    ("SHOCKLINK_FW_VERSION", "0.8.1")
+    ("SHOCKLINK_API_URL", "\"api.shocklink.net\""),
+    ("SHOCKLINK_DEV_API_URL", "\"dev-api.shocklink.net\""),
+    ("SHOCKLINK_FW_VERSION", "\"0.8.1\"")
 ])
 
 print(env.Dump())

--- a/embed_firmware_version.py
+++ b/embed_firmware_version.py
@@ -1,4 +1,10 @@
 
 Import("env")
 
+env.Append(CPPDEFINES=[
+    ("SHOCKLINK_API_URL", "api.shocklink.net"),
+    ("SHOCKLINK_DEV_API_URL", "dev-api.shocklink.net"),
+    ("SHOCKLINK_FW_VERSION", "0.8.1")
+])
+
 print(env.Dump())

--- a/embed_firmware_version.py
+++ b/embed_firmware_version.py
@@ -2,9 +2,9 @@
 Import("env")
 
 env.Append(CPPDEFINES=[
-    ("SHOCKLINK_API_URL", "\"api.shocklink.net\""),
-    ("SHOCKLINK_DEV_API_URL", "\"dev-api.shocklink.net\""),
-    ("SHOCKLINK_FW_VERSION", "\"0.8.1\"")
+    ("SHOCKLINK_API_URL", env.StringifyMacro("api.shocklink.net")),
+    ("SHOCKLINK_DEV_API_URL", env.StringifyMacro("dev-api.shocklink.net")),
+    ("SHOCKLINK_FW_VERSION", env.StringifyMacro("0.8.1"))
 ])
 
 print(env.Dump())

--- a/embed_firmware_version.py
+++ b/embed_firmware_version.py
@@ -1,0 +1,4 @@
+
+Import("env")
+
+print(env.Dump())

--- a/embed_version.py
+++ b/embed_version.py
@@ -5,7 +5,6 @@ Import("env")
 # This file is invoked by PlatformIO during build.
 # See "extra_scripts" in "platformio.ini".
 
-
 # Fetch environment variables, with sane defaults if not found.
 # These variables should be defined by the CI.
 shocklinkApiUrl = os.getenv('SHOCKLINK_API_URL') or "api.shocklink.net"

--- a/embed_version.py
+++ b/embed_version.py
@@ -2,10 +2,19 @@ import os
 
 Import("env")
 
+# This file is invoked by PlatformIO during build.
+# See "extra_scripts" in "platformio.ini".
+
+
+# Fetch environment variables, with sane defaults if not found.
+# These variables should be defined by the CI.
 shocklinkApiUrl = os.getenv('SHOCKLINK_API_URL') or "api.shocklink.net"
 shocklinkFwVersion = os.getenv('SHOCKLINK_FW_VERSION') or "0.8.1"
 
+# Define these variables as macros for expansion during build time.
 env.Append(CPPDEFINES=[
     ("SHOCKLINK_API_URL", env.StringifyMacro(shocklinkApiUrl)),
     ("SHOCKLINK_FW_VERSION", env.StringifyMacro(shocklinkFwVersion))
 ])
+
+print(env.Dump())

--- a/embed_version.py
+++ b/embed_version.py
@@ -16,5 +16,3 @@ env.Append(CPPDEFINES=[
     ("SHOCKLINK_API_URL", env.StringifyMacro(shocklinkApiUrl)),
     ("SHOCKLINK_FW_VERSION", env.StringifyMacro(shocklinkFwVersion))
 ])
-
-print(env.Dump())

--- a/embed_version.py
+++ b/embed_version.py
@@ -9,5 +9,3 @@ env.Append(CPPDEFINES=[
     ("SHOCKLINK_API_URL", env.StringifyMacro(shocklinkApiUrl)),
     ("SHOCKLINK_FW_VERSION", env.StringifyMacro(shocklinkFwVersion))
 ])
-
-print(env.Dump())

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,4 +20,4 @@ lib_deps =
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 board_build.partitions = huge_app.csv
 extra_scripts =
-	pre:embed_firmware_version.py
+	pre:embed_version.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,5 @@ lib_deps =
 	links2004/WebSockets@^2.3.7
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 board_build.partitions = huge_app.csv
+extra_scripts =
+	pre:embed_firmware_version.py

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -16,9 +16,6 @@
 #include <LedManager.h>
 #include <Version.h>
 
-const String apiUrl = "api.shocklink.net";
-const String devApiUrl = "dev-api.shocklink.net";
-
 WiFiMulti WiFiMulti;
 WebSocketsClient webSocket;
 TaskHandle_t Task1;
@@ -292,8 +289,8 @@ void setup()
     String authToken = authTokenFile.readString();
     authTokenFile.close();
 
-    webSocket.setExtraHeaders(("FirmwareVersion:" + versionString + "\r\nDeviceToken: " + authToken).c_str());
-    webSocket.beginSSL(apiUrl, 443, "/1/ws/device");
+    webSocket.setExtraHeaders(("FirmwareVersion:" + SHOCKLINK_FW_VERSION + "\r\nDeviceToken: " + authToken).c_str());
+    webSocket.beginSSL(SHOCKLINK_API_URL, 443, "/1/ws/device");
     webSocket.onEvent(webSocketEvent);
     runner.addTask(keepalive);
     keepalive.enable();
@@ -421,7 +418,7 @@ void loop()
                 SPIFFS.remove("/pairCode");
 
                 HTTPClient http;
-                String uri = "https://" + apiUrl + "/1/pair/" + pairCode;
+                String uri = "https://" + SHOCKLINK_API_URL + "/1/pair/" + pairCode;
 
                 Serial.print("Contacting pair code url: ");
                 Serial.println(uri);

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -228,7 +228,7 @@ void setup()
     Serial.println();
     Serial.println();
     Serial.print("==== ShockLink v");
-    Serial.print(SHOCKLINK_FW_VERSION);
+    Serial.print(shocklinkFwVersion);
     Serial.println(" ====");
 
     LedManager::Loop(WL_IDLE_STATUS, false, 0);

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -14,7 +14,6 @@
 #include "SPIFFS.h"
 #include "HTTPClient.h"
 #include <LedManager.h>
-#include <Version.h>
 
 WiFiMulti WiFiMulti;
 WebSocketsClient webSocket;

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -15,6 +15,9 @@
 #include "HTTPClient.h"
 #include <LedManager.h>
 
+const String shocklinkApiUrl = SHOCKLINK_API_URL;
+const String shocklinkFwVersion = SHOCKLINK_FW_VERSION;
+
 WiFiMulti WiFiMulti;
 WebSocketsClient webSocket;
 TaskHandle_t Task1;
@@ -288,8 +291,8 @@ void setup()
     String authToken = authTokenFile.readString();
     authTokenFile.close();
 
-    webSocket.setExtraHeaders(("FirmwareVersion:" + SHOCKLINK_FW_VERSION + "\r\nDeviceToken: " + authToken).c_str());
-    webSocket.beginSSL(SHOCKLINK_API_URL, 443, "/1/ws/device");
+    webSocket.setExtraHeaders(("FirmwareVersion:" + shocklinkFwVersion + "\r\nDeviceToken: " + authToken).c_str());
+    webSocket.beginSSL(shocklinkApiUrl, 443, "/1/ws/device");
     webSocket.onEvent(webSocketEvent);
     runner.addTask(keepalive);
     keepalive.enable();
@@ -417,7 +420,7 @@ void loop()
                 SPIFFS.remove("/pairCode");
 
                 HTTPClient http;
-                String uri = String("https://") + SHOCKLINK_API_URL + "/1/pair/" + pairCode;
+                String uri = "https://" + shocklinkApiUrl + "/1/pair/" + pairCode;
 
                 Serial.print("Contacting pair code url: ");
                 Serial.println(uri);

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -417,7 +417,7 @@ void loop()
                 SPIFFS.remove("/pairCode");
 
                 HTTPClient http;
-                String uri = "https://" + SHOCKLINK_API_URL + "/1/pair/" + pairCode;
+                String uri = String("https://") + SHOCKLINK_API_URL + "/1/pair/" + pairCode;
 
                 Serial.print("Contacting pair code url: ");
                 Serial.println(uri);

--- a/src/ShockLink.cpp
+++ b/src/ShockLink.cpp
@@ -229,7 +229,7 @@ void setup()
     Serial.println();
     Serial.println();
     Serial.print("==== ShockLink v");
-    Serial.print(versionString);
+    Serial.print(SHOCKLINK_FW_VERSION);
     Serial.println(" ====");
 
     LedManager::Loop(WL_IDLE_STATUS, false, 0);

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,0 @@
-const String versionString = "0.8.0";


### PR DESCRIPTION
Hi,

I've added two environment variables to the CI:
- `SHOCKLINK_API_URL` that contains the API URL (`api.shocklink.net` by default)
- `SHOCKLINK_FW_VERSION` that contains:
  - On the `master` branch the value `master-${{ github.sha }}`
  - On a tag release the name of the tag, e.g. `v0.7.5`.

In `platformio.ini` I've added an `extra_scripts = pre:embed.version.py` to append a single build script. See the build script in question for more info.

